### PR TITLE
fix: nginx config syntax error causing container crash on start

### DIFF
--- a/falah-os-workspace/Dockerfile
+++ b/falah-os-workspace/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:alpine
 RUN rm -rf /usr/share/nginx/html/*
 COPY dist/ /usr/share/nginx/html/
-RUN printf 'server{\nlisten 80;\nroot /usr/share/nginx/html;\nindex index.html;\nlocation/{\ntry_files $uri $uri/ /index.html;\n}\n}' > /etc/nginx/conf.d/default.conf
+RUN printf 'server {\n  listen 80;\n  root /usr/share/nginx/html;\n  index index.html;\n  location / {\n    try_files $uri $uri/ /index.html;\n  }\n}\n' > /etc/nginx/conf.d/default.conf
 EXPOSE 80


### PR DESCRIPTION
## Bug

`location/` in the nginx `printf` string was missing a space before `/`, making it `location/` instead of `location /`. nginx rejects this as a parse error and the container exits immediately on start.

## Fix

Corrected to `location / {` with proper spacing and indentation throughout the config block.

## Test

```bash
curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | bash
# → container starts, http://server-ip:8088 loads Falah OS dashboard
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr)_