### PR TITLE
fix: full working backend — all 4 services in single Docker image

### DIFF
--- a/falah-os-workspace/Dockerfile
+++ b/falah-os-workspace/Dockerfile
@@ -1,5 +1,73 @@
-FROM nginx:alpine
-RUN rm -rf /usr/share/nginx/html/*
-COPY dist/ /usr/share/nginx/html/
-RUN printf 'server {\n  listen 80;\n  root /usr/share/nginx/html;\n  index index.html;\n  location / {\n    try_files $uri $uri/ /index.html;\n  }\n}\n' > /etc/nginx/conf.d/default.conf
+# ════════════════════════════════════════════════════════════════
+#  Falah OS Community Edition — Production Image
+#  Services: MessageBus → Gateway → Core + AppManagement + UI
+# ════════════════════════════════════════════════════════════════
+
+# ── Stage 1: Build all Go services ──────────────────────────────
+FROM golang:1.21-alpine AS go-builder
+
+RUN apk add --no-cache git
+
+WORKDIR /src
+
+# MessageBus (cloned from upstream IceWhale)
+RUN git clone --depth 1 https://github.com/IceWhaleTech/CasaOS-MessageBus.git && \
+    cd CasaOS-MessageBus && \
+    go mod download && \
+    CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/message-bus .
+
+# Gateway — copy go.mod first for layer caching
+COPY CasaOS-Gateway/go.mod CasaOS-Gateway/go.sum ./CasaOS-Gateway/
+RUN cd CasaOS-Gateway && go mod download
+COPY CasaOS-Gateway/ ./CasaOS-Gateway/
+RUN cd CasaOS-Gateway && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/gateway .
+
+# Core
+COPY CasaOS/go.mod CasaOS/go.sum ./CasaOS/
+RUN cd CasaOS && go mod download
+COPY CasaOS/ ./CasaOS/
+RUN cd CasaOS && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/core .
+
+# AppManagement
+COPY CasaOS-AppManagement/go.mod CasaOS-AppManagement/go.sum ./CasaOS-AppManagement/
+RUN cd CasaOS-AppManagement && go mod download
+COPY CasaOS-AppManagement/ ./CasaOS-AppManagement/
+RUN cd CasaOS-AppManagement && CGO_ENABLED=0 go build -ldflags="-s -w" -o /out/appmgmt .
+
+# ── Stage 2: Runtime image ───────────────────────────────────────
+FROM alpine:3.18
+
+RUN apk add --no-cache supervisor ca-certificates bash tzdata
+
+# Copy compiled binaries
+COPY --from=go-builder /out/message-bus  /usr/local/bin/falahos-message-bus
+COPY --from=go-builder /out/gateway      /usr/local/bin/falahos-gateway
+COPY --from=go-builder /out/core         /usr/local/bin/falahos-core
+COPY --from=go-builder /out/appmgmt      /usr/local/bin/falahos-appmgmt
+
+# Runtime and data directories
+RUN mkdir -p \
+    /var/run/casaos \
+    /var/lib/casaos/www \
+    /var/lib/casaos/db \
+    /var/lib/casaos/apps \
+    /var/lib/casaos/istore \
+    /var/lib/casaos/conf \
+    /var/log/casaos \
+    /etc/casaos \
+    /usr/share/casaos/shell
+
+# Pre-built Falah OS frontend
+COPY dist/ /var/lib/casaos/www/
+
+# Service config files
+COPY config/falahos.conf          /etc/casaos/falahos.conf
+COPY config/gateway.ini           /etc/casaos/gateway.ini
+COPY config/app-management.conf   /etc/casaos/app-management.conf
+
+# Supervisord config
+COPY supervisord.conf /etc/supervisord.conf
+
 EXPOSE 80
+
+CMD ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisord.conf"]

--- a/falah-os-workspace/config/app-management.conf
+++ b/falah-os-workspace/config/app-management.conf
@@ -1,0 +1,12 @@
+[common]
+RuntimePath = /var/run/casaos
+
+[app]
+LogPath = /var/log/casaos/
+LogSaveName = app-management
+LogFileExt = log
+AppStorePath = /var/lib/casaos/istore
+AppsPath = /var/lib/casaos/apps
+
+[server]
+appstore = https://api.falah-consultancy.ltd/istore/apps.json

--- a/falah-os-workspace/config/falahos.conf
+++ b/falah-os-workspace/config/falahos.conf
@@ -1,0 +1,14 @@
+[app]
+LogPath = /var/log/casaos/
+LogSaveName = falahos
+LogFileExt = log
+DBPath = /var/lib/casaos
+ShellPath = /usr/share/casaos/shell
+UserDataPath = /var/lib/casaos/conf
+
+[server]
+RunMode = release
+ServerApi = https://api.casaos.io/casaos-api
+
+[common]
+RuntimePath = /var/run/casaos

--- a/falah-os-workspace/config/gateway.ini
+++ b/falah-os-workspace/config/gateway.ini
@@ -1,0 +1,5 @@
+[common]
+runtimepath=/var/run/casaos
+
+[gateway]
+port=

--- a/falah-os-workspace/docker-compose.yml
+++ b/falah-os-workspace/docker-compose.yml
@@ -1,95 +1,24 @@
-# ─────────────────────────────────────────────────────────────────
-#  Falah OS Community Edition v1.0 — Docker Compose
-#  Usage: docker compose up -d
-# ─────────────────────────────────────────────────────────────────
+# ════════════════════════════════════════════════════════════════
+#  Falah OS Community Edition — Docker Compose
+#  Usage:  docker compose up -d --build
+#  UI:     http://your-server-ip
+# ════════════════════════════════════════════════════════════════
 version: "3.9"
 
-networks:
-  falahos_network:
-    driver: bridge
+services:
+  falahos:
+    build: .
+    container_name: falahos
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - falahos_data:/var/lib/casaos
+      - falahos_config:/etc/casaos
+      - falahos_logs:/var/log/casaos
+    restart: unless-stopped
 
 volumes:
   falahos_data:
   falahos_config:
-  falahos_apps:
-
-services:
-
-  # ── Falah OS Gateway (reverse proxy / service router) ──────────
-  falahos-gateway:
-    image: golang:1.21-alpine
-    container_name: falahos-gateway
-    working_dir: /app
-    command: >
-      sh -c "apk add --no-cache git &&
-             cd /app/CasaOS-Gateway &&
-             go run . 2>&1 || echo 'Gateway: run go run . after go mod download'"
-    volumes:
-      - .:/app:ro
-      - falahos_config:/etc/falahos
-    ports:
-      - "80:80"
-      - "443:443"
-    networks:
-      - falahos_network
-    restart: unless-stopped
-
-  # ── Falah OS App Management ────────────────────────────────────
-  falahos-app-management:
-    image: golang:1.21-alpine
-    container_name: falahos-app-management
-    working_dir: /app
-    command: >
-      sh -c "apk add --no-cache git &&
-             cd /app/CasaOS-AppManagement &&
-             go run . 2>&1 || echo 'AppMgmt: run go run . after go mod download'"
-    volumes:
-      - .:/app:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-      - falahos_data:/var/lib/falahos
-      - falahos_config:/etc/falahos
-    networks:
-      - falahos_network
-    restart: unless-stopped
-    depends_on:
-      - falahos-gateway
-
-  # ── Falah OS Dashboard (Vue.js served via nginx) ───────────────
-  falahos-ui:
-    image: node:18-alpine
-    container_name: falahos-ui
-    working_dir: /app/CasaOS-UI
-    command: >
-      sh -c "npm install --legacy-peer-deps --silent &&
-             npm run serve -- --port 3000 --host 0.0.0.0"
-    environment:
-      - NODE_ENV=development
-      - VITE_APP_NAME=Falah OS
-      - VUE_APP_TITLE=Falah OS Community Edition
-    volumes:
-      - ./CasaOS-UI:/app/CasaOS-UI
-    ports:
-      - "3000:3000"
-    networks:
-      - falahos_network
-    restart: unless-stopped
-
-  # ── Falah OS Core ──────────────────────────────────────────────
-  falahos-core:
-    image: golang:1.21-alpine
-    container_name: falahos-core
-    working_dir: /app
-    command: >
-      sh -c "apk add --no-cache git &&
-             cd /app/CasaOS &&
-             go run . 2>&1 || echo 'Core: run go run . after go mod download'"
-    volumes:
-      - .:/app:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-      - falahos_data:/var/lib/falahos
-      - falahos_config:/etc/falahos
-    networks:
-      - falahos_network
-    restart: unless-stopped
-    depends_on:
-      - falahos-gateway
+  falahos_logs:

--- a/falah-os-workspace/install.sh
+++ b/falah-os-workspace/install.sh
@@ -3,9 +3,8 @@ set -euo pipefail
 
 REPO="https://github.com/maiforslab/digitalpro.git"
 BRANCH="master"
-WORK_DIR="/tmp/falahos-$$"
+INSTALL_DIR="/opt/falahos"
 CONTAINER_NAME="falahos"
-PORT="${PORT:-8088}"
 
 printf '\n'
 printf '  ███████╗ █████╗ ██╗      █████╗ ██╗  ██╗     ██████╗ ███████╗\n'
@@ -15,13 +14,13 @@ printf '  ██╔══╝  ██╔══██║██║     ██╔═
 printf '  ██║     ██║  ██║███████╗██║  ██║██║  ██║    ╚██████╔╝███████║\n'
 printf '  ╚═╝     ╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝     ╚═════╝ ╚══════╝\n'
 printf '\n'
-printf '  Falah OS Community Edition — One-Line Installer\n'
+printf '  Falah OS Community Edition — Installer\n'
 printf '\n'
 
 # --- Preflight checks ---
 if ! command -v docker &>/dev/null; then
   printf 'Error: Docker is not installed.\n'
-  printf 'Install it first: https://docs.docker.com/get-docker/\n'
+  printf 'Install it: https://docs.docker.com/get-docker/\n'
   exit 1
 fi
 
@@ -30,30 +29,31 @@ if ! command -v git &>/dev/null; then
   exit 1
 fi
 
-printf '[1/4] Downloading Falah OS (shallow clone)...\n'
-git clone --depth 1 --branch "$BRANCH" "$REPO" "$WORK_DIR" --quiet
+printf '[1/4] Downloading Falah OS...\n'
+if [ -d "$INSTALL_DIR/.git" ]; then
+  git -C "$INSTALL_DIR" pull origin "$BRANCH" --quiet
+else
+  rm -rf "$INSTALL_DIR"
+  git clone --depth 1 --branch "$BRANCH" "$REPO" "$INSTALL_DIR" --quiet
+fi
 
-printf '[2/4] Building Docker image...\n'
-docker build -t falahos "$WORK_DIR/falah-os-workspace" --quiet
+cd "$INSTALL_DIR/falah-os-workspace"
 
-printf '[3/4] Removing any existing Falah OS container...\n'
-docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+printf '[2/4] Building Docker image (this takes ~5 min on first run)...\n'
+docker compose build --quiet
 
-printf '[4/4] Starting Falah OS on port %s...\n' "$PORT"
-docker run -d \
-  --name "$CONTAINER_NAME" \
-  -p "${PORT}:80" \
-  --restart unless-stopped \
-  falahos
+printf '[3/4] Stopping any existing Falah OS container...\n'
+docker compose down 2>/dev/null || true
 
-rm -rf "$WORK_DIR"
+printf '[4/4] Starting all Falah OS services...\n'
+docker compose up -d
 
 IP=$(hostname -I 2>/dev/null | awk '{print $1}') || IP="your-server-ip"
 
 printf '\n'
-printf '  ✓ Falah OS is live at:  http://%s:%s\n' "$IP" "$PORT"
+printf '  ✓ Falah OS is live at:  http://%s\n' "$IP"
 printf '\n'
-printf '  To stop:    docker stop falahos\n'
-printf '  To restart: docker start falahos\n'
-printf '  To update:  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | bash\n'
+printf '  Logs:    docker logs -f falahos\n'
+printf '  Stop:    cd %s && docker compose down\n' "$INSTALL_DIR/falah-os-workspace"
+printf '  Update:  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | bash\n'
 printf '\n'

--- a/falah-os-workspace/portainer-stack.yml
+++ b/falah-os-workspace/portainer-stack.yml
@@ -1,7 +1,25 @@
+# ════════════════════════════════════════════════════════════════
+#  Falah OS Community Edition — Portainer Stack
+#  Requires: repo cloned to the Portainer host first
+#  Build:    docker build -t falahos /path/to/falah-os-workspace
+#  Then paste this file into Portainer → Stacks → Add Stack
+# ════════════════════════════════════════════════════════════════
 version: "3.9"
+
 services:
   falahos:
-    build: .
+    image: falahos:latest
+    container_name: falahos
     ports:
-      - "8088:80"
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - falahos_data:/var/lib/casaos
+      - falahos_config:/etc/casaos
+      - falahos_logs:/var/log/casaos
     restart: unless-stopped
+
+volumes:
+  falahos_data:
+  falahos_config:
+  falahos_logs:

--- a/falah-os-workspace/supervisord.conf
+++ b/falah-os-workspace/supervisord.conf
@@ -1,0 +1,58 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/casaos/supervisord.log
+loglevel=info
+pidfile=/var/run/supervisord.pid
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+# ── 1. Message Bus — starts first, all other services depend on it
+[program:message-bus]
+command=/usr/local/bin/falahos-message-bus
+autostart=true
+autorestart=true
+priority=10
+stdout_logfile=/var/log/casaos/message-bus.log
+stderr_logfile=/var/log/casaos/message-bus.log
+stdout_logfile_maxbytes=10MB
+stderr_logfile_maxbytes=10MB
+
+# ── 2. Gateway — waits for message-bus to write its URL file
+[program:gateway]
+command=/bin/sh -c "until [ -f /var/run/casaos/message-bus.url ]; do sleep 1; done; exec /usr/local/bin/falahos-gateway -w /var/lib/casaos/www"
+autostart=true
+autorestart=true
+priority=20
+stdout_logfile=/var/log/casaos/gateway.log
+stderr_logfile=/var/log/casaos/gateway.log
+stdout_logfile_maxbytes=10MB
+stderr_logfile_maxbytes=10MB
+
+# ── 3a. Core — waits for gateway to write its management URL
+[program:core]
+command=/bin/sh -c "until [ -f /var/run/casaos/management.url ]; do sleep 1; done; exec /usr/local/bin/falahos-core -c /etc/casaos/falahos.conf"
+autostart=true
+autorestart=true
+priority=30
+stdout_logfile=/var/log/casaos/core.log
+stderr_logfile=/var/log/casaos/core.log
+stdout_logfile_maxbytes=10MB
+stderr_logfile_maxbytes=10MB
+
+# ── 3b. AppManagement — waits for gateway management URL
+[program:appmgmt]
+command=/bin/sh -c "until [ -f /var/run/casaos/management.url ]; do sleep 1; done; exec /usr/local/bin/falahos-appmgmt -c /etc/casaos/app-management.conf"
+autostart=true
+autorestart=true
+priority=30
+stdout_logfile=/var/log/casaos/appmgmt.log
+stderr_logfile=/var/log/casaos/appmgmt.log
+stdout_logfile_maxbytes=10MB
+stderr_logfile_maxbytes=10MB


### PR DESCRIPTION
## Problem

The previous deployment served only the static Vue.js frontend (nginx). Without the backend, every API call failed silently → blank dashboard.

CasaOS is a 4-service architecture that all need to run together:
`MessageBus → Gateway → Core + AppManagement`

## Fix

Multi-stage Dockerfile that compiles and runs all 4 services in a single container managed by supervisord.

### What changed

| File | Change |
|------|--------|
| `Dockerfile` | Multi-stage: Go builder (MessageBus cloned from upstream + Gateway + Core + AppMgmt compiled) → alpine runtime with supervisord |
| `supervisord.conf` | Startup ordering via `until [ -f url-file ]` wait loops: MessageBus first, then Gateway, then Core+AppMgmt |
| `config/falahos.conf` | Core service config — runtime path `/var/run/casaos` |
| `config/gateway.ini` | Gateway config — runtime path `/var/run/casaos`, auto port |
| `config/app-management.conf` | AppMgmt config — iStore URL, runtime path standardised |
| `docker-compose.yml` | Single `falahos` service, Docker socket mounted for app management |
| `install.sh` | Uses `docker compose build + up` |

## Deploy

```bash
curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | bash
```

First run builds all Go binaries (~5 min). Subsequent runs are fast (Docker layer cache).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr)_