### PR TITLE
fix: auto-escalate to sudo in install.sh

### DIFF
--- a/falah-os-workspace/install.sh
+++ b/falah-os-workspace/install.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Re-execute with sudo if not root
+if [ "$(id -u)" -ne 0 ]; then
+  exec sudo bash "$0" "$@"
+fi
+
 REPO="https://github.com/maiforslab/digitalpro.git"
 BRANCH="master"
 INSTALL_DIR="/opt/falahos"


### PR DESCRIPTION
Adds a root check at the top of `install.sh` — if not running as root, re-executes itself with `sudo`. Fixes `Permission denied` when cloning to `/opt/falahos`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr)_