### PR TITLE
fix: require sudo bash in one-liner installer

### DIFF
--- a/falah-os-workspace/install.sh
+++ b/falah-os-workspace/install.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Re-execute with sudo if not root
+# Require root (sudo)
 if [ "$(id -u)" -ne 0 ]; then
-  exec sudo bash "$0" "$@"
+  printf 'Error: run with sudo:\n'
+  printf '  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | sudo bash\n'
+  exit 1
 fi
 
 REPO="https://github.com/maiforslab/digitalpro.git"
@@ -60,5 +62,5 @@ printf '  ✓ Falah OS is live at:  http://%s\n' "$IP"
 printf '\n'
 printf '  Logs:    docker logs -f falahos\n'
 printf '  Stop:    cd %s && docker compose down\n' "$INSTALL_DIR/falah-os-workspace"
-printf '  Update:  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | bash\n'
+printf '  Update:  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | sudo bash\n'
 printf '\n'


### PR DESCRIPTION
The `exec sudo bash "$0"` re-exec trick doesn't work when the script is piped from `curl` — `$0` resolves to `/dev/stdin`, not a file. Replaced with a clean error message that prints the correct `sudo bash` command.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr)_