### PR TITLE
fix: install to $HOME/falahos — no sudo required

### DIFF
--- a/falah-os-workspace/install.sh
+++ b/falah-os-workspace/install.sh
@@ -1,16 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Require root (sudo)
-if [ "$(id -u)" -ne 0 ]; then
-  printf 'Error: run with sudo:\n'
-  printf '  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | sudo bash\n'
-  exit 1
-fi
-
 REPO="https://github.com/maiforslab/digitalpro.git"
 BRANCH="master"
-INSTALL_DIR="/opt/falahos"
+INSTALL_DIR="${HOME:-$PWD}/falahos"
 CONTAINER_NAME="falahos"
 
 printf '\n'
@@ -62,5 +55,5 @@ printf '  ✓ Falah OS is live at:  http://%s\n' "$IP"
 printf '\n'
 printf '  Logs:    docker logs -f falahos\n'
 printf '  Stop:    cd %s && docker compose down\n' "$INSTALL_DIR/falah-os-workspace"
-printf '  Update:  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | sudo bash\n'
+printf '  Update:  curl -fsSL https://raw.githubusercontent.com/maiforslab/digitalpro/master/falah-os-workspace/install.sh | bash\n'
 printf '\n'


### PR DESCRIPTION
Removes all sudo requirements. Installs to `$HOME/falahos` instead of `/opt/falahos` — any user can write there without elevated permissions. The one-liner goes back to plain `bash`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr)_