### PR TITLE
fix: point install.sh at master after PR #13 merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,7 @@ bash deploy-cloudrun.sh <GCP_PROJECT_ID> [REGION]
 ---
 
 ## Active Branch
-`claude/falah-os-v1-build-dmw7p` — open PR #13 against master.
-`install.sh` currently clones this branch for testing; revert `BRANCH=master` before merging.
+`master` — PR #13 merged. `install.sh` correctly clones `master`.
 
 ---
 

--- a/falah-os-workspace/install.sh
+++ b/falah-os-workspace/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 REPO="https://github.com/maiforslab/digitalpro.git"
-BRANCH="claude/falah-os-v1-build-dmw7p"
+BRANCH="master"
 INSTALL_DIR="${HOME:-$PWD}/falahos"
 CONTAINER_NAME="falahos"
 


### PR DESCRIPTION
## Summary
- `install.sh` was left pointing at `claude/falah-os-v1-build-dmw7p` for end-to-end testing during PR #13
- Now that PR #13 is merged, end-users should clone `master`
- Also updates `CLAUDE.md` to reflect the merged state

## Test plan
- [ ] Run `curl -fsSL .../install.sh | bash` and confirm it clones `master`

https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr)_