### PR TITLE
fix: Portainer deploy path + UserService data persistence

### DIFF
--- a/falah-os-workspace/docker-compose.yml
+++ b/falah-os-workspace/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       # Persistent data only — do NOT mount /var/lib/falahos wholesale
       # as it hides the UI files baked into /usr/share/falahos/www in the image
       - falahos_casaos_db:/var/lib/casaos/db
+      - falahos_userservice_db:/var/lib/casaos/user-service/db
       - falahos_core_db:/var/lib/falahos/db
       - falahos_core_conf:/var/lib/falahos/conf
       - falahos_apps:/var/lib/falahos/apps
@@ -30,6 +31,7 @@ services:
 
 volumes:
   falahos_casaos_db:
+  falahos_userservice_db:
   falahos_core_db:
   falahos_core_conf:
   falahos_apps:

--- a/falah-os-workspace/portainer-stack.yml
+++ b/falah-os-workspace/portainer-stack.yml
@@ -1,7 +1,12 @@
 # ════════════════════════════════════════════════════════════════
 #  Falah OS Community Edition — Portainer Stack
-#  In Portainer: Stacks → Add Stack → Web editor → paste this file
-#  Image is pulled automatically from GitHub Container Registry
+#
+#  PORTAINER REPOSITORY MODE: use THIS file, not docker-compose.yml
+#    Stacks → Add Stack → Repository
+#    Compose path: falah-os-workspace/portainer-stack.yml
+#
+#  Pulls the pre-built image from GitHub Container Registry.
+#  (docker-compose.yml triggers a local build which fails in Portainer)
 # ════════════════════════════════════════════════════════════════
 
 services:
@@ -18,8 +23,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Persistent data only — do NOT mount /var/lib/falahos wholesale
-      # as it hides the UI files baked into the image
+      # as it hides the UI files baked into /usr/share/falahos/www in the image
       - falahos_casaos_db:/var/lib/casaos/db
+      - falahos_userservice_db:/var/lib/casaos/user-service/db
       - falahos_core_db:/var/lib/falahos/db
       - falahos_core_conf:/var/lib/falahos/conf
       - falahos_apps:/var/lib/falahos/apps
@@ -30,6 +36,7 @@ services:
 
 volumes:
   falahos_casaos_db:
+  falahos_userservice_db:
   falahos_core_db:
   falahos_core_conf:
   falahos_apps:


### PR DESCRIPTION
## Summary

- **Fix Portainer Repository build failure**: `portainer-stack.yml` header now explicitly states it must be used as the Compose path in Portainer Repository mode (`falah-os-workspace/portainer-stack.yml`). Using `docker-compose.yml` triggers a local `docker build` that fails when cloning CasaOS-UserService.
- **Add UserService data volume**: Both `portainer-stack.yml` and `docker-compose.yml` now mount `falahos_userservice_db` at `/var/lib/casaos/user-service/db` so registered user accounts survive container restarts.

## Root cause of Portainer deploy failure

Portainer Repository mode runs `docker compose build` locally. `docker-compose.yml` has `build: .` which triggers the full multi-stage Dockerfile build on the VPS — this fails at the `git clone CasaOS-UserService` step (network timeout or OOM). `portainer-stack.yml` has `image: ghcr.io/maiforslab/digitalpro:latest` and skips the build entirely.

## Test plan

- [ ] In Portainer: Stacks → Add Stack → Repository → set Compose path to `falah-os-workspace/portainer-stack.yml` → Deploy
- [ ] Container starts, all 5 services log as started
- [ ] `http://<vps-ip>:7080` shows the Falah OS login page
- [ ] Register a user, restart the container, verify the account still exists

https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqL8mj8pxCEcApJQiG5PRr)_